### PR TITLE
Add NewsAPI headlines tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Run the server with SSE transport:
 python server.py
 ```
 
-Make sure the environment variables `OPENAI_API_KEY` and `RUNWARE_API_KEY` are
-set to enable image and audio generation. Video stitching requires `ffmpeg` to
+Make sure the environment variables `OPENAI_API_KEY`, `RUNWARE_API_KEY` and
+`NEWSAPI_KEY` are set to enable image, audio and news retrieval. Video stitching requires `ffmpeg` to
 be installed along with the Python packages `moviepy`, `Pillow` and `numpy`.
 
 `generate_video` expects two arguments: a JSON string describing the scenes and a
@@ -95,6 +95,7 @@ docker run -p 8000:8000 \
   -e PORT=8000 \
   -e OPENAI_API_KEY=... \
   -e RUNWARE_API_KEY=... \
+  -e NEWSAPI_KEY=... \
   shortmcp
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ dependencies = [
     "numpy>=1.26.4",
     "Pillow>=9.5.0",
     "python-dotenv==1.0.1",
+    "newsapi-python>=0.2.7",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ runware==0.4.13
 moviepy==1.0.3
 numpy==1.26.4
 Pillow==9.5.0
+newsapi-python==0.2.7


### PR DESCRIPTION
## Summary
- add newsapi-python dependency
- expose `get_headlines` MCP tool for fetching news headlines
- document required `NEWSAPI_KEY` environment variable

## Testing
- `python -m py_compile server.py video_generator.py main.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6856f07c98a08322b21471d634e99993